### PR TITLE
Fast money four

### DIFF
--- a/src/FastMoney.js
+++ b/src/FastMoney.js
@@ -4,12 +4,15 @@ import domUpdates from './domUpdates.js';
 class FastMoney extends Round {
   constructor(survey, answers, players) {
     super(survey, answers, players);
-    console.log(this.players)
   }
 
-  logGuesses(playerID, guess) {
-    playerID === 1 ? this.players[0].fmGuesses.push(guess.toUpperCase()) : this.players[1].fmGuesses.push(guess.toUpperCase());
-    console.log('guesses', this.players)
+  logGuesses(guess) {
+    let player = this.determineCurrentPlayer();
+    player.fmGuesses.push(guess.toUpperCase());
+    console.log(this.players);
+    console.log('player', player)
+    console.log('turn count', this.turnCounter)
+    // playerID === 1 ? this.players[0].fmGuesses.push(guess.toUpperCase()) : this.players[1].fmGuesses.push(guess.toUpperCase());
   }
 
   checkGuesses() {

--- a/src/FastMoney.js
+++ b/src/FastMoney.js
@@ -9,10 +9,6 @@ class FastMoney extends Round {
   logGuesses(guess) {
     let player = this.determineCurrentPlayer();
     player.fmGuesses.push(guess.toUpperCase());
-    console.log(this.players);
-    console.log('player', player)
-    console.log('turn count', this.turnCounter)
-    // playerID === 1 ? this.players[0].fmGuesses.push(guess.toUpperCase()) : this.players[1].fmGuesses.push(guess.toUpperCase());
   }
 
   checkGuesses() {

--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ $('#submit-guess').on('keypress click', (e) => {
     } else {
       let guess = $('#guess-input').val();
       $('#guess-input').val('');
-      game.currentRound.logGuesses(game.currentRound.turnCounter, guess)
+      game.currentRound.logGuesses(guess)
     }
   }
 })
@@ -151,8 +151,8 @@ function countdown() {
   timer.style.color = 'black';
   if (timeLeft == -1) {
     clearTimeout(timerId);
-    game.roundCounter++
     countDOM()
+    game.currentRound.turnCounter++
   } else if(timeLeft <= 5) {
     timer.style.color = '#F05355';
     timer.innerHTML = `TIME: ${timeLeft} SEC`;
@@ -164,12 +164,13 @@ function countdown() {
 };
 
 function countDOM() {
-  if (game.roundCounter < 6) {
+  console.log(game.currentRound.turnCounter)
+  if (game.currentRound.turnCounter === 1) {
     $('#submit-guess').prop('disabled', true);
     domUpdates.displayFastMoneyModal2('FAST MONEY');
     timer.innerHTML = 'TIME: 30 SEC'
   }
-  if (game.roundCounter >= 6) {
+  if (game.currentRound.turnCounter === 2) {
   $('#submit-guess').prop('disabled', true);
   game.currentRound.endGame()
   }


### PR DESCRIPTION
We had a few issues with fast money running 3 times in a row and the player guesses from fast money both going into the first player guesses array. By changing the use of roundCount to turnCount and using the determine player method to determine what round fast count is in and who is playing, we believe these issues are now fixed.